### PR TITLE
Split into base and view

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,168 @@
+---
+Language:        Cpp
+# BasedOnStyle:  Google
+AccessModifierOffset: -1
+AlignAfterOpenBracket: Align
+AlignConsecutiveMacros: false
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlines: Left
+AlignOperands:   true
+AlignTrailingComments: true
+AllowAllArgumentsOnNextLine: true
+AllowAllConstructorInitializersOnNextLine: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortBlocksOnASingleLine: Never
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: All
+AllowShortLambdasOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: WithoutElse
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: true
+AlwaysBreakTemplateDeclarations: Yes
+BinPackArguments: true
+BinPackParameters: false
+BraceWrapping:
+  AfterCaseLabel:  false
+  AfterClass:      false
+  AfterControlStatement: false
+  AfterEnum:       false
+  AfterFunction:   true
+  AfterNamespace:  false
+  AfterObjCDeclaration: false
+  AfterStruct:     false
+  AfterUnion:      false
+  AfterExternBlock: false
+  BeforeCatch:     true
+  BeforeElse:      true
+  IndentBraces:    false
+  SplitEmptyFunction: false
+  SplitEmptyRecord: false
+  SplitEmptyNamespace: false
+BreakBeforeBinaryOperators: None
+BreakBeforeBraces: Custom
+BreakBeforeInheritanceComma: false
+BreakInheritanceList: BeforeColon
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: false
+BreakConstructorInitializers: BeforeColon
+BreakAfterJavaFieldAnnotations: false
+BreakStringLiterals: true
+ColumnLimit:     80
+CommentPragmas:  '^ IWYU pragma:'
+CompactNamespaces: false
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DeriveLineEnding: true
+DerivePointerAlignment: false
+DisableFormat:   false
+ExperimentalAutoDetectBinPacking: false
+FixNamespaceComments: true
+ForEachMacros:
+  - foreach
+  - Q_FOREACH
+  - BOOST_FOREACH
+IncludeBlocks:   Regroup
+IncludeCategories:
+  - Regex:           '^<ext/.*\.h>'
+    Priority:        2
+    SortPriority:    0
+  - Regex:           '^<.*\.h>'
+    Priority:        1
+    SortPriority:    0
+  - Regex:           '^<.*'
+    Priority:        2
+    SortPriority:    0
+  - Regex:           '.*'
+    Priority:        3
+    SortPriority:    0
+IncludeIsMainRegex: '([-_](test|unittest))?$'
+IncludeIsMainSourceRegex: ''
+IndentCaseLabels: true
+IndentGotoLabels: true
+IndentPPDirectives: BeforeHash
+IndentWidth:     4
+IndentWrappedFunctionNames: false
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepEmptyLinesAtTheStartOfBlocks: false
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: Inner
+ObjCBinPackProtocolList: Never
+ObjCBlockIndentWidth: 2
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: true
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 1
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyBreakTemplateDeclaration: 10
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 200
+PointerAlignment: Left
+RawStringFormats:
+  - Language:        Cpp
+    Delimiters:
+      - cc
+      - CC
+      - cpp
+      - Cpp
+      - CPP
+      - 'c++'
+      - 'C++'
+    CanonicalDelimiter: ''
+    BasedOnStyle:    google
+  - Language:        TextProto
+    Delimiters:
+      - pb
+      - PB
+      - proto
+      - PROTO
+    EnclosingFunctions:
+      - EqualsProto
+      - EquivToProto
+      - PARSE_PARTIAL_TEXT_PROTO
+      - PARSE_TEST_PROTO
+      - PARSE_TEXT_PROTO
+      - ParseTextOrDie
+      - ParseTextProtoOrDie
+    CanonicalDelimiter: ''
+    BasedOnStyle:    google
+ReflowComments:  true
+SortIncludes:    true
+SortUsingDeclarations: true
+SpaceAfterCStyleCast: false
+SpaceAfterLogicalNot: false
+SpaceAfterTemplateKeyword: true
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCpp11BracedList: false
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpaceBeforeParens: ControlStatements
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceInEmptyBlock: false
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 2
+SpacesInAngles:  false
+SpacesInConditionalStatement: false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+SpaceBeforeSquareBrackets: false
+Standard:        Auto
+StatementMacros:
+  - Q_UNUSED
+  - QT_REQUIRE_VERSION
+TabWidth:        8
+UseCRLF:         false
+UseTab:          Never
+...
+

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,0 @@
-
-CPPFLAGS=-std=c++20 -Wall -Wextra -pedantic -g
-
-test: test.cpp vector.hpp matrix.hpp matrix_operations.hpp vector_operations.hpp
-	g++ $(CPPFLAGS) -o test test.cpp -lblas -llapack
-
-clean:	
-	rm -f test *.o *.mod

--- a/Readme.md
+++ b/Readme.md
@@ -61,25 +61,45 @@ v[0] = 5; // This will not compile
 
 You can create submatrices and subvectors using the `submatrix` and `subvector` functions. For example, to create a submatrix of the first 3 rows and 4 columns of a matrix `m`, you can use the following code:
 ```cpp
-tws::matrix<> sub = m.submatrix(0, 3, 0, 4);
+tws::matrixview<> sub = m.submatrix(0, 3, 0, 4);
 ```
-The `sub` matrix will be a view into the original matrix `m`, so changing elements in `sub` will also change the corresponding elements in `m`. If you don't want this behavior, you can create a copy of the submatrix:
+The `sub` matrix will be a view into the original matrix `m`, so changing elements in `sub` will also change the corresponding elements in `m`. If you don't want this behavior, you can declare `sub` as a matrix instead of a matrixview:
 ```cpp
-    tws::matrix<> sub(3,4);
-    sub = m.submatrix(0, 3, 0, 4);
+    tws::matrix<> sub = m.submatrix(0, 3, 0, 4);
 ```
 The same applies to subvectors.
 
 You can also select a row or a column of a matrix using the `row` and `colomn` functions. For example, to select the second row of a matrix `m`, you can use the following code:
 ```cpp
-tws::vector<> row = m.row(1);
+tws::vectorview<> row = m.row(1);
 ```
 To select the third column of a matrix `m`, you can use the following code:
 ```cpp
-tws::vector<> column = m.column(2);
+tws::vectorview<> column = m.column(2);
 ```
 Just like a submatrix or subvector, a row or a column is a view into the original matrix, so changing elements in the row or column will also change the corresponding elements in the original matrix.
 
+### Passing matrices and vectors to functions
+
+An important decision when passing anything to a function is whether to pass by value or by reference.
+
+If you pass a `matrix` or a `vector` by value, a copy of the matrix or vector will be made and changes made to the matrix or vector inside the function will not affect the original matrix or vector.
+
+If you pass a `matrix` or a `vector` by reference, no copy will be made and changes made to the matrix or vector inside the function will affect the original matrix or vector. If you don't want the original to be modified, you can pass it as a `const` reference.
+
+The `matrixview` and `vectorview` classes are a bit special. They are always references to some other matrix/vector. Even if you pass them by value, changes made to the view will affect the original matrix/vector.
+
+Finally, you may want to write a function that can accept both a `vector` and a `vectorview`. You can do this by using a template argument. For example, the following function will work with both `vector` and `vectorview`:
+```cpp
+template <Vector V>
+void print_vector(const V& v) {
+    for (int i = 0; i < v.size(); i++) {
+        std::cout << v[i] << " ";
+    }
+    std::cout << std::endl;
+}
+```
+Be careful when using this, as the behavior of `vector` and `vectorview` is subtly different, like when passing it by value so make sure it can handle both cases.
 
 ### Useful operations
 
@@ -91,8 +111,8 @@ You can also multiply two matrices using the `operator*`:
 ```cpp
 tws::matrix<> result = m1 * m2;
 ```
-These functions will automatically check if the dimensions of the matrices are compatible for the operation.\\
-\newline
+These functions will automatically check if the dimensions of the matrices are compatible for the operation.
+
 They will also create a new matrix to store the results. As mentioned before, this can be expensive if you are doing many operations in a loop. To avoid performance issues, you can use the alternative function `multiply`, which multiplies two matrices and stores the result in a pre-allocated matrix:
 ```cpp
 tws::matrix<> result(10, 15);

--- a/Readme.md
+++ b/Readme.md
@@ -15,6 +15,8 @@ and make sure that the compiler knows where to find the header files. We recomme
 - Create a new environment variable called `MATRIXLIBRARY` and set it to the directory where the header files are located. Note, this is not just the directory where you cloned this repository but the `include/` directory within it. To avoid having to recreate this variable every time you open a new terminal, you can add the following line to your `.bashrc` or `.bash_profile` file: `export MATRIXLIBRARY=/path/to/header/files`.
 - When you compile your code, add the following flag to the compiler command:`-I$(MATRIXLIBRARY)`. This tells the compiler to look for header files in the directory specified by the `MATRIXLIBRARY` environment variable.
 
+**Imporant note: the library uses C++20 features so make sure you compile with the `-std=c++20` flag.** 
+
 ## Usage
 
 ### Creating a vector or matrix

--- a/include/matrix.hpp
+++ b/include/matrix.hpp
@@ -7,6 +7,7 @@
 #include <chrono>
 #include <functional>
 #include <iostream>
+#include <memory>
 #include <random>
 
 #include "vector.hpp"
@@ -15,7 +16,7 @@ namespace tws {
 
 // This defines a matrix as an abstract concept.
 // You can safely ignore this untill you have learned about concepts.
-#if(__cplusplus >= 202002L)
+#if (__cplusplus >= 202002L)
 
 template <typename M>
 concept Matrix = requires(M m)
@@ -24,14 +25,18 @@ concept Matrix = requires(M m)
     {m.num_rows()};
     {m.num_columns()};
     {m.size()};
-    {m(0,0)};
+    {m(0, 0)};
 };
 
 #else
 
-#define Matrix typename
+    #define Matrix typename
 
 #endif
+
+// Forward declaration of the matrixview class
+template <typename T = double>
+class matrixview;
 
 /**
  * A matrix class that can be used to store matrices of arbitrary size.
@@ -45,7 +50,6 @@ template <typename T = double>
 class matrix {
    public:
     typedef T val_t;
-    typedef int idx_t;
 
    public:
     /**
@@ -53,101 +57,84 @@ class matrix {
      *
      * @param m  integer
      *           Number of rows of the matrix
-     * 
+     *
      * @param n  integer
      *           Number of columns of the matrix
      */
-    matrix(idx_t m, idx_t n)
-        : m_(m),
-          n_(n),
-          ldim_(m),
-          locally_allocated_(true),
-          data_(new T[m_ * n_])
+    matrix(int m, int n) : _m(m), _n(n), _data(new T[_m * _n])
     {
-        #ifndef NDEBUG
-        std::fill(data_, data_ + m_ * n_, NAN);
-        #endif
-    }
-
-    /**
-     * @brief Construct a new Matrix without allocating memory
-     *
-     * @param m    integer
-     *             Number of rows of the matrix
-     * 
-     * @param n    integer
-     *             Number of columns of the matrix
-     * 
-     * @param ptr  pointer to the data
-     *             Pointer to the data of the matrix
-     *             Note: this constructor does not check whether the data
-     *             pointed to by ptr is large enough to store the matrix.
-     *             Use this constructor with caution.
-     * 
-     * @param ldim integer
-     *             Leading dimension of the matrix
-     */
-    matrix(idx_t m, idx_t n, T* ptr, idx_t ldim)
-        : m_(m), n_(n), ldim_(ldim), locally_allocated_(false), data_(ptr)
-    {
-        assert(ldim >= m);
+#ifndef NDEBUG
+        if constexpr (std::is_floating_point<T>::value) {
+            for (int j = 0; j < _n; ++j) {
+                for (int i = 0; i < _m; ++i) {
+                    _data[i + j * _m] = std::nan("1");
+                }
+            }
+        }
+#endif
     }
 
     // Destructor
     ~matrix()
     {
-        if (locally_allocated_) {
-            delete[] data_;
-        }
+        // Nothing to do here, the shared pointer will take care of the memory
     }
 
     /**
      * @brief Construct a new Matrix object as a copy of another matrix
-     *
-     * Note: this contructor makes a deep copy of the matrix and allocates
-     * new memory to facilitate this.
+     *        This does a deep copy
      *
      * @param m Matrix
      *          Matrix to copy
      */
     matrix(const matrix& m)
-        : m_(m.num_rows()),
-          n_(m.num_columns()),
-          ldim_(m.num_rows()),
-          locally_allocated_(true),
-          data_(new T[m.num_rows() * m.num_columns()])
+        : _m(m.num_rows()),
+          _n(m.num_columns()),
+          _data(new T[m.num_rows() * m.num_columns()])
     {
         for (int j = 0; j < m.num_columns(); ++j) {
             for (int i = 0; i < m.num_rows(); ++i) {
-                data_[i + j * ldim_] = m(i, j);
+                _data[i + j * _m] = m(i, j);
+            }
+        }
+    }
+
+    /**
+     * @brief Construct a new Matrix object as a copy of another matrix
+     *        This does a deep copy
+     *
+     * This is a templated version, you can safely ignore this untill you
+     * have learned about expression templates and more advanced C++ features.
+     *
+     * @param m Matrix
+     *          Matrix to copy
+     */
+    template <Matrix M>
+    matrix(const M& m)
+        : _m(m.num_rows()),
+          _n(m.num_columns()),
+          _data(new T[m.num_rows() * m.num_columns()])
+    {
+        for (int j = 0; j < m.num_columns(); ++j) {
+            for (int i = 0; i < m.num_rows(); ++i) {
+                _data[i + j * _m] = m(i, j);
             }
         }
     }
 
     /**
      * @brief Construct a new Matrix object by moving the data of another matrix
-     *        Note, we do a deep copy and not a shallow copy
-     *        even though the given matrix is temporary.
+     *        This does a shallow copy
      *
      * @param m Matrix
      *          Matrix to move
      */
-    matrix(matrix&& m)
-        : m_(m.num_rows()),
-          n_(m.num_columns()),
-          ldim_(m.num_rows()),
-          locally_allocated_(true),
-          data_(new T[m.num_rows() * m.num_columns()])
-    {
-        for (int j = 0; j < m.num_columns(); ++j) {
-            for (int i = 0; i < m.num_rows(); ++i) {
-                data_[i + j * ldim_] = m(i, j);
-            }
-        }
-    }
+    matrix(matrix&& m) : _m(m.num_rows()), _n(m.num_columns()), _data(m._data)
+    {}
 
     /**
      * @brief Assign the data of another matrix to this matrix
+     *        This does a deep copy
      *
      * @param m Matrix
      *          Matrix to copy
@@ -156,11 +143,11 @@ class matrix {
      */
     matrix& operator=(const matrix& m)
     {
-        assert(m.num_rows() == m_);
-        assert(m.num_columns() == n_);
-        for (int i = 0; i < m_; ++i) {
-            for (int j = 0; j < n_; ++j) {
-                data_[i + j * ldim_] = m(i, j);
+        assert(m.num_rows() == _m);
+        assert(m.num_columns() == _n);
+        for (int i = 0; i < _m; ++i) {
+            for (int j = 0; j < _n; ++j) {
+                _data[i + j * _m] = m(i, j);
             }
         }
         return *this;
@@ -168,7 +155,10 @@ class matrix {
 
     /**
      * @brief Assign the data of another matrix to this matrix
-     *        templated version
+     *        This does a deep copy
+     *
+     * This is a templated version, you can safely ignore this untill you
+     * have learned about expression templates and more advanced C++ features.
      *
      * @param m Matrix
      *          Matrix to copy
@@ -178,11 +168,11 @@ class matrix {
     template <Matrix M>
     matrix& operator=(const M& m)
     {
-        assert(m.num_rows() == m_);
-        assert(m.num_columns() == n_);
-        for (int i = 0; i < m_; ++i) {
-            for (int j = 0; j < n_; ++j) {
-                data_[i + j * ldim_] = m(i, j);
+        assert(m.num_rows() == _m);
+        assert(m.num_columns() == _n);
+        for (int i = 0; i < _m; ++i) {
+            for (int j = 0; j < _n; ++j) {
+                _data[i + j * _m] = m(i, j);
             }
         }
         return *this;
@@ -190,8 +180,7 @@ class matrix {
 
     /**
      * @brief Assign the data of another matrix to this matrix
-     *        Note, we do a deep copy and not a shallow copy
-     *        even though the given matrix is temporary.
+     *        This does a shallow copy
      *
      * @param m Matrix
      *          Matrix to copy
@@ -200,27 +189,20 @@ class matrix {
      */
     matrix& operator=(matrix&& m)
     {
-        assert(m.num_rows() == m_);
-        assert(m.num_columns() == n_);
-        for (int i = 0; i < m_; ++i) {
-            for (int j = 0; j < n_; ++j) {
-                data_[i + j * ldim_] = m(i, j);
-            }
-        }
+        assert(m.num_rows() == _m);
+        assert(m.num_columns() == _n);
+        _data = m._data;
         return *this;
     }
 
     // Returns the number of rows of the matrix
-    inline idx_t num_rows() const { return m_; }
+    inline int num_rows() const { return _m; }
 
     // Returns the number of columns of the matrix
-    inline idx_t num_columns() const { return n_; }
-
-    // Returns the leading dimension of the matrix
-    inline idx_t ldim() const { return ldim_; }
+    inline int num_columns() const { return _n; }
 
     // Returns the size of the matrix (i.e. the number of elements m * n)
-    inline idx_t size() const { return n_ * m_; }
+    inline int size() const { return _n * _m; }
 
     /**
      * @brief Access the ij-th element of the matrix
@@ -234,9 +216,9 @@ class matrix {
      */
     inline const T& operator()(int i, int j) const
     {
-        assert(i < m_);
-        assert(j < n_);
-        return data_[i + j * ldim_];
+        assert(i < _m);
+        assert(j < _n);
+        return _data[i + j * _m];
     }
 
     /**
@@ -250,9 +232,9 @@ class matrix {
      */
     inline T& operator()(int i, int j)
     {
-        assert(i < m_);
-        assert(j < n_);
-        return data_[i + j * ldim_];
+        assert(i < _m);
+        assert(j < _n);
+        return _data[i + j * _m];
     }
 
     /**
@@ -271,15 +253,15 @@ class matrix {
      * though the returned object is not const. Solving this problem would
      * require either an inefficient or a more complex design.
      */
-    inline matrix submatrix(idx_t i1, idx_t i2, idx_t j1, idx_t j2) const
+    inline matrixview<T> submatrix(int i1, int i2, int j1, int j2) const
     {
         assert(i1 >= 0);
-        assert(i2 <= m_);
+        assert(i2 <= _m);
         assert(j1 >= 0);
-        assert(j2 <= n_);
+        assert(j2 <= _n);
         assert(i1 < i2);
         assert(j1 < j2);
-        return matrix(i2 - i1, j2 - j1, &data_[i1 + j1 * ldim_], ldim_);
+        return matrixview<T>(i2 - i1, j2 - j1, _data, _m, i1 + j1 * _m);
     }
 
     /**
@@ -291,11 +273,11 @@ class matrix {
      * though the returned object is not const. Solving this problem would
      * require either an inefficient or a more complex design.
      */
-    inline vector<T> column(idx_t i) const
+    inline vectorview<T> column(int i) const
     {
         assert(i >= 0);
-        assert(i < n_);
-        return vector<T>(m_, &data_[i * ldim_], 1);
+        assert(i < _n);
+        return vectorview<T>(_m, _data, 1, i * _m);
     }
 
     /**
@@ -307,34 +289,281 @@ class matrix {
      * though the returned object is not const. Solving this problem would
      * require either an inefficient or a more complex design.
      */
-    inline vector<T> row(idx_t i) const
+    inline vectorview<T> row(int i) const
     {
         assert(i >= 0);
-        assert(i < m_);
-        return vector<T>(n_, &data_[i], ldim_);
+        assert(i < _m);
+        return vectorview<T>(_n, _data, _m, i);
     }
 
     /**
      * Return a pointer to the data of the matrix.
      */
-    inline T* data() { return data_; }
+    inline T* data() { return _data.get(); }
 
     /**
      * Return a pointer to the data of the matrix.
      */
-    inline const T* data() const { return data_; }
+    inline const T* data() const { return _data.get(); }
 
    private:
     // Number of rows of the matrix
-    const idx_t m_;
+    const int _m;
     // Number of columns of the matrix
-    const idx_t n_;
-    // Leading dimension of the matrix
-    const idx_t ldim_;
-    // Whether the matrix owns the data or not
-    const bool locally_allocated_;
+    const int _n;
     // Pointer to the data
-    T* data_;
+    std::shared_ptr<T[]> _data;
+};
+
+/**
+ * A matrix class that can be used to store matrices of arbitrary size.
+ *
+ * The elements of the matrix are stored in column-major order
+ *
+ * @tparam T this is a template parameter that specifies the type of the
+ *           elements of the vector.
+ */
+template <typename T>
+class matrixview {
+   public:
+    typedef T val_t;
+
+   public:
+    /**
+     * @brief Construct a new Matrixview
+     *
+     * @param m      integer
+     *               Number of rows of the matrix
+     *
+     * @param n      integer
+     *               Number of columns of the matrix
+     *
+     * @param data   shared_ptr<T[]>
+     *               Pointer to the data of the matrix
+     *
+     * @param ldim   integer
+     *               Leading dimension of the matrix
+     *               i.e. the number of elements between
+     *               two elements of the same row.
+     *
+     * @param offset integer
+     *               Offset of the matrix
+     */
+    matrixview(int m, int n, std::shared_ptr<T[]> data, int ldim, int offset)
+        : _m(m), _n(n), _ldim(ldim), _offset(offset), _data(data)
+    {
+        assert(_ldim >= _m);
+    }
+
+    // Destructor
+    ~matrixview()
+    {
+        // Nothing to do here, the shared pointer will take care of the memory
+    }
+
+    /**
+     * @brief Construct a new matrixview object as a copy of another matrixview
+     *        This does a shallow copy
+     *
+     * @param m matrixview
+     *          Matrix to copy
+     */
+    matrixview(const matrixview& m)
+        : _m(m.num_rows()),
+          _n(m.num_columns()),
+          _ldim(m.ldim()),
+          _offset(m.offset()),
+          _data(m._data)
+    {}
+
+    /**
+     * @brief Construct a new Matrix object by moving the data of another matrix
+     *        This does a shallow copy
+     *
+     * @param m Matrix
+     *          Matrix to move
+     */
+    matrixview(matrixview&& m)
+        : _m(m.num_rows()),
+          _n(m.num_columns()),
+          _ldim(m.ldim()),
+          _offset(m.offset()),
+          _data(m._data)
+    {}
+
+    /**
+     * @brief Assign the data of another matrix to this matrix
+     *        This does a shallow copy
+     *
+     * @param m Matrix
+     *          Matrix to copy
+     * @return  Matrix&
+     *          Reference to this matrix (used for chaining assignments)
+     */
+    matrixview& operator=(const matrixview& m)
+    {
+        assert(m.num_rows() == _m);
+        assert(m.num_columns() == _n);
+        assert(m.ldim() == _ldim);
+        assert(m.offset() == _offset);
+        _data = m._data;
+        return *this;
+    }
+
+    /**
+     * @brief Assign the data of another matrix to this matrix
+     *        This does a shallow copy
+     *
+     * @param m Matrix
+     *          Matrix to copy
+     * @return  Matrix&
+     *          Reference to this matrix (used for chaining assignments)
+     */
+    matrixview& operator=(matrixview&& m)
+    {
+        assert(m.num_rows() == _m);
+        assert(m.num_columns() == _n);
+        assert(m.ldim() == _ldim);
+        assert(m.offset() == _offset);
+        _data = m._data;
+        return *this;
+    }
+
+    // Returns the number of rows of the matrix
+    inline int num_rows() const { return _m; }
+
+    // Returns the number of columns of the matrix
+    inline int num_columns() const { return _n; }
+
+    // Returns the leading dimension of the matrix
+    inline int ldim() const { return _ldim; }
+
+    // Returns the size of the matrix (i.e. the number of elements m * n)
+    inline int size() const { return _n * _m; }
+
+    // Returns the offset of the matrix
+    // (The number of elements in the data before the first element of the
+    // matrix)
+    inline int offset() const { return _offset; }
+
+    /**
+     * @brief Access the ij-th element of the matrix
+     *
+     * @param i integer
+     *          Row index
+     * @param j integer
+     *          Column index
+     * @return  const T&
+     *          Because this matrix is const, we return a const reference.
+     */
+    inline const T& operator()(int i, int j) const
+    {
+        assert(i < _m);
+        assert(i >= 0);
+        assert(j < _n);
+        assert(j >= 0);
+        return _data[_offset + i + j * _ldim];
+    }
+
+    /**
+     * @brief Access the ij-th element of the matrix
+     *
+     * @param i integer
+     *          Row index
+     * @param j integer
+     *          Column index
+     * @return  T&
+     */
+    inline T& operator()(int i, int j)
+    {
+        assert(i < _m);
+        assert(i >= 0);
+        assert(j < _n);
+        assert(j >= 0);
+        return _data[_offset + i + j * _ldim];
+    }
+
+    /**
+     * Return a submatrix of the matrix.
+     *
+     * @param i1 index of the first row of the submatrix
+     * @param i2 index of the last row of the submatrix (not inclusive)
+     * @param j1 index of the first column of the submatrix
+     * @param j2 index of the last column of the submatrix (not inclusive)
+     *
+     * @example
+     * Matrix<float> A(5,5);
+     * auto B = A.submatrix(1, 4, 1, 4); // B is a 3x3 submatrix of A
+     *
+     * Note: this function will also be called if the matrix is const, even
+     * though the returned object is not const. Solving this problem would
+     * require either an inefficient or a more complex design.
+     */
+    inline matrixview submatrix(int i1, int i2, int j1, int j2) const
+    {
+        assert(i1 >= 0);
+        assert(i2 <= _m);
+        assert(j1 >= 0);
+        assert(j2 <= _n);
+        assert(i1 < i2);
+        assert(j1 < j2);
+        return matrixview(i2 - i1, j2 - j1, _data, _ldim,
+                          _offset + i1 + j1 * _ldim);
+    }
+
+    /**
+     * Return a column of matrix as a vector
+     *
+     * @param i index of the column
+     *
+     * Note: this function will also be called if the matrix is const, even
+     * though the returned object is not const. Solving this problem would
+     * require either an inefficient or a more complex design.
+     */
+    inline vectorview<T> column(int i) const
+    {
+        assert(i >= 0);
+        assert(i < _n);
+        return vectorview<T>(_m, _data, 1, _offset + i * _ldim);
+    }
+
+    /**
+     * Return a row of matrix as a vector
+     *
+     * @param i index of the row
+     *
+     * Note: this function will also be called if the matrix is const, even
+     * though the returned object is not const. Solving this problem would
+     * require either an inefficient or a more complex design.
+     */
+    inline vectorview<T> row(int i) const
+    {
+        assert(i >= 0);
+        assert(i < _m);
+        return vectorview<T>(_n, _data, _ldim, _offset + i);
+    }
+
+    /**
+     * Return a pointer to the data of the matrix.
+     */
+    inline T* data() { return _data.get(); }
+
+    /**
+     * Return a pointer to the data of the matrix.
+     */
+    inline const T* data() const { return _data.get(); }
+
+   private:
+    // Number of rows of the matrix
+    const int _m;
+    // Number of columns of the matrix
+    const int _n;
+    // Leading dimension of the matrix
+    const int _ldim;
+    // Offset of the matrix
+    const int _offset;
+    // Pointer to the data
+    std::shared_ptr<T[]> _data;
 };
 
 // Code for printing

--- a/include/matrix.hpp
+++ b/include/matrix.hpp
@@ -15,7 +15,7 @@
 namespace tws {
 
 // This defines a matrix as an abstract concept.
-// You can safely ignore this untill you have learned about concepts.
+// You can safely ignore this until you have learned about concepts.
 template <typename M>
 concept Matrix = requires(M m)
 {
@@ -97,7 +97,7 @@ class matrix {
      * @brief Construct a new Matrix object as a copy of another matrix
      *        This does a deep copy
      *
-     * This is a templated version, you can safely ignore this untill you
+     * This is a templated version, you can safely ignore this until you
      * have learned about expression templates and more advanced C++ features.
      *
      * @param m Matrix
@@ -151,7 +151,7 @@ class matrix {
      * @brief Assign the data of another matrix to this matrix
      *        This does a deep copy
      *
-     * This is a templated version, you can safely ignore this untill you
+     * This is a templated version, you can safely ignore this until you
      * have learned about expression templates and more advanced C++ features.
      *
      * @param m Matrix

--- a/include/matrix.hpp
+++ b/include/matrix.hpp
@@ -40,6 +40,8 @@ class matrixview;
  */
 template <Scalar T = double>
 class matrix {
+    friend class matrixview<T>;
+
    public:
     typedef T val_t;
 
@@ -369,6 +371,20 @@ class matrixview {
     {}
 
     /**
+     * @brief Construct a new matrixview object as a view of a matrix
+     *
+     * @param m matrix
+     *          Matrix to view
+     */
+    matrixview(const matrix<T>& m)
+        : _m(m.num_rows()),
+          _n(m.num_columns()),
+          _ldim(m.num_rows()),
+          _offset(0),
+          _data(m._data)
+    {}
+
+    /**
      * @brief Construct a new Matrix object by moving the data of another matrix
      *        This does a shallow copy
      *
@@ -394,10 +410,10 @@ class matrixview {
      */
     matrixview& operator=(const matrixview& m)
     {
-        assert(m.num_rows() == _m);
-        assert(m.num_columns() == _n);
-        assert(m.ldim() == _ldim);
-        assert(m.offset() == _offset);
+        _m = m._m;
+        _n = m._n;
+        _ldim = m._ldim;
+        _offset = m._offset;
         _data = m._data;
         return *this;
     }
@@ -413,10 +429,10 @@ class matrixview {
      */
     matrixview& operator=(matrixview&& m)
     {
-        assert(m.num_rows() == _m);
-        assert(m.num_columns() == _n);
-        assert(m.ldim() == _ldim);
-        assert(m.offset() == _offset);
+        _m = m._m;
+        _n = m._n;
+        _ldim = m._ldim;
+        _offset = m._offset;
         _data = m._data;
         return *this;
     }
@@ -547,13 +563,13 @@ class matrixview {
 
    private:
     // Number of rows of the matrix
-    const int _m;
+    int _m;
     // Number of columns of the matrix
-    const int _n;
+    int _n;
     // Leading dimension of the matrix
-    const int _ldim;
+    int _ldim;
     // Offset of the matrix
-    const int _offset;
+    int _offset;
     // Pointer to the data
     std::shared_ptr<T[]> _data;
 };

--- a/include/matrix.hpp
+++ b/include/matrix.hpp
@@ -559,8 +559,8 @@ class matrixview {
 };
 
 // Code for printing
-template <Scalar T>
-void print_matrix(const matrix<T>& m)
+template <Matrix M>
+void print_matrix(const M& m)
 {
     std::cout << "(" << m.num_rows() << "," << m.num_columns() << ")["
               << std::endl;
@@ -575,12 +575,33 @@ void print_matrix(const matrix<T>& m)
 }
 
 // Initialize a matrix with random values
-template <Scalar T>
-void randomize(matrix<T>& m)
+template <Matrix M>
+void randomize(M& m)
 {
-    for (int j = 0; j < m.num_columns(); ++j) {
-        for (int i = 0; i < m.num_rows(); ++i) {
-            m(i, j) = (T)rand() / RAND_MAX;
+#ifdef NDEBUG
+    std::random_device rd;
+    std::mt19937 gen(rd());
+#else
+    // Note, when debugging, we want to have the same random numbers every time
+    std::mt19937 gen(1302);
+#endif
+
+    typedef typename M::val_t T;
+
+    if constexpr (std::is_integral<T>::value) {
+        std::uniform_int_distribution<T> d(0, 100);
+        for (int j = 0; j < m.num_columns(); ++j) {
+            for (int i = 0; i < m.num_rows(); ++i) {
+                m(i, j) = d(gen);
+            }
+        }
+    }
+    else {
+        std::normal_distribution<T> d(0, 1);
+        for (int j = 0; j < m.num_columns(); ++j) {
+            for (int i = 0; i < m.num_rows(); ++i) {
+                m(i, j) = d(gen);
+            }
         }
     }
 }

--- a/include/matrix.hpp
+++ b/include/matrix.hpp
@@ -198,6 +198,9 @@ class matrix {
     // Returns the size of the matrix (i.e. the number of elements m * n)
     inline int size() const { return _n * _m; }
 
+    // Returns the leading dimension of the matrix
+    inline int ldim() const { return _m; }
+
     /**
      * @brief Access the ij-th element of the matrix
      *

--- a/include/matrix.hpp
+++ b/include/matrix.hpp
@@ -16,8 +16,6 @@ namespace tws {
 
 // This defines a matrix as an abstract concept.
 // You can safely ignore this untill you have learned about concepts.
-#if (__cplusplus >= 202002L)
-
 template <typename M>
 concept Matrix = requires(M m)
 {
@@ -28,14 +26,8 @@ concept Matrix = requires(M m)
     {m(0, 0)};
 };
 
-#else
-
-    #define Matrix typename
-
-#endif
-
 // Forward declaration of the matrixview class
-template <typename T = double>
+template <Scalar T = double>
 class matrixview;
 
 /**
@@ -46,7 +38,7 @@ class matrixview;
  * @tparam T this is a template parameter that specifies the type of the
  *           elements of the vector.
  */
-template <typename T = double>
+template <Scalar T = double>
 class matrix {
    public:
     typedef T val_t;
@@ -246,7 +238,7 @@ class matrix {
      * @param j2 index of the last column of the submatrix (not inclusive)
      *
      * @example
-     * Matrix<float> A(5,5);
+     * matrix<float> A(5,5);
      * auto B = A.submatrix(1, 4, 1, 4); // B is a 3x3 submatrix of A
      *
      * Note: this function will also be called if the matrix is const, even
@@ -323,7 +315,7 @@ class matrix {
  * @tparam T this is a template parameter that specifies the type of the
  *           elements of the vector.
  */
-template <typename T>
+template <Scalar T>
 class matrixview {
    public:
     typedef T val_t;
@@ -492,7 +484,7 @@ class matrixview {
      * @param j2 index of the last column of the submatrix (not inclusive)
      *
      * @example
-     * Matrix<float> A(5,5);
+     * matrix<float> A(5,5);
      * auto B = A.submatrix(1, 4, 1, 4); // B is a 3x3 submatrix of A
      *
      * Note: this function will also be called if the matrix is const, even
@@ -567,7 +559,7 @@ class matrixview {
 };
 
 // Code for printing
-template <typename T>
+template <Scalar T>
 void print_matrix(const matrix<T>& m)
 {
     std::cout << "(" << m.num_rows() << "," << m.num_columns() << ")["
@@ -583,7 +575,7 @@ void print_matrix(const matrix<T>& m)
 }
 
 // Initialize a matrix with random values
-template <typename T>
+template <Scalar T>
 void randomize(matrix<T>& m)
 {
     for (int j = 0; j < m.num_columns(); ++j) {

--- a/include/matrix.hpp
+++ b/include/matrix.hpp
@@ -274,7 +274,7 @@ class matrix {
     {
         assert(i >= 0);
         assert(i < _n);
-        return vectorview<T>(_m, _data, 1, i * _m);
+        return vectorview<T>(_m, &_data[i * _m], 1);
     }
 
     /**
@@ -290,7 +290,7 @@ class matrix {
     {
         assert(i >= 0);
         assert(i < _m);
-        return vectorview<T>(_n, _data, _m, i);
+        return vectorview<T>(_n, &_data[i], _m);
     }
 
     /**
@@ -535,7 +535,7 @@ class matrixview {
     {
         assert(i >= 0);
         assert(i < _n);
-        return vectorview<T>(_m, _data, 1, _offset + i * _ldim);
+        return vectorview<T>(_m, &_data[_offset + i * _ldim], 1);
     }
 
     /**
@@ -551,7 +551,7 @@ class matrixview {
     {
         assert(i >= 0);
         assert(i < _m);
-        return vectorview<T>(_n, _data, _ldim, _offset + i);
+        return vectorview<T>(_n, &_data[_offset + i], _ldim);
     }
 
     /**

--- a/include/matrix_operations.hpp
+++ b/include/matrix_operations.hpp
@@ -9,10 +9,11 @@
 namespace tws {
 
 // Matrix-vector multiplication, store the result in a new vector
-template <typename T>
-vector<T> operator*(const matrix<T>& A, const vector<T>& v) {
+template <Matrix M, Vector V>
+auto operator*(const M& A, const V& v)
+{
     assert(A.num_columns() == v.size());
-    vector<T> result(A.num_rows());
+    vector<std::remove_const_t<typename M::val_t>> result(A.num_rows());
     for (int i = 0; i < A.num_rows(); ++i) {
         result[i] = 0;
         for (int j = 0; j < A.num_columns(); ++j) {
@@ -23,8 +24,9 @@ vector<T> operator*(const matrix<T>& A, const vector<T>& v) {
 }
 
 // Matrix-vector multiplication, store the result in a given vector
-template <typename T>
-void multiply(const matrix<T>& A, const vector<T>& v, vector<T>& result) {
+template <Matrix M, Vector V1, Vector V2>
+void multiply(const M& A, const V1& v, V2& result)
+{
     assert(A.num_columns() == v.size());
     assert(A.num_rows() == result.size());
     for (int i = 0; i < A.num_rows(); ++i) {
@@ -36,10 +38,12 @@ void multiply(const matrix<T>& A, const vector<T>& v, vector<T>& result) {
 }
 
 // Matrix-matrix multiplication, store the result in a new matrix
-template <typename T>
-matrix<T> operator*(const matrix<T>& A, const matrix<T>& B) {
+template <Matrix M1, Matrix M2>
+auto operator*(const M1& A, const M2& B)
+{
     assert(A.num_columns() == B.num_rows());
-    matrix<T> result(A.num_rows(), B.num_columns());
+    matrix<std::remove_const_t<typename M1::val_t>> result(A.num_rows(),
+                                                           B.num_columns());
     for (int i = 0; i < A.num_rows(); ++i) {
         for (int j = 0; j < B.num_columns(); ++j) {
             result(i, j) = 0;
@@ -52,8 +56,9 @@ matrix<T> operator*(const matrix<T>& A, const matrix<T>& B) {
 }
 
 // Matrix-matrix multiplication, store the result in a given matrix
-template <typename T>
-void multiply(const matrix<T>& A, const matrix<T>& B, matrix<T>& result) {
+template <Matrix M1, Matrix M2, Matrix M3>
+void multiply(const M1& A, const M2& B, M3& result)
+{
     assert(A.num_columns() == B.num_rows());
     assert(A.num_rows() == result.num_rows());
     assert(B.num_columns() == result.num_columns());
@@ -68,9 +73,11 @@ void multiply(const matrix<T>& A, const matrix<T>& B, matrix<T>& result) {
 }
 
 // Transpose of a matrix, store the result in a new matrix
-template <typename T>
-matrix<T> transpose(const matrix<T>& A) {
-    matrix<T> result(A.num_columns(), A.num_rows());
+template <Matrix M>
+auto transpose(const M& A)
+{
+    matrix<std::remove_const_t<typename M::val_t>> result(A.num_columns(),
+                                                          A.num_rows());
     for (int i = 0; i < A.num_rows(); ++i) {
         for (int j = 0; j < A.num_columns(); ++j) {
             result(j, i) = A(i, j);
@@ -80,8 +87,9 @@ matrix<T> transpose(const matrix<T>& A) {
 }
 
 // Transpose of a matrix, store the result in a given matrix
-template <typename T>
-void transpose(const matrix<T>& A, matrix<T>& result) {
+template <Matrix M1, Matrix M2>
+void transpose(const M1& A, M2& result)
+{
     assert(A.num_rows() == result.num_columns());
     assert(A.num_columns() == result.num_rows());
     for (int i = 0; i < A.num_rows(); ++i) {
@@ -92,9 +100,10 @@ void transpose(const matrix<T>& A, matrix<T>& result) {
 }
 
 // Frobenius norm of a matrix
-template <typename T>
-T norm(const matrix<T>& A) {
-    T result = 0;
+template <Matrix M>
+auto norm(const M& A)
+{
+    std::remove_const_t<typename M::val_t> result = 0;
     for (int i = 0; i < A.num_rows(); ++i) {
         for (int j = 0; j < A.num_columns(); ++j) {
             result += A(i, j) * A(i, j);
@@ -103,7 +112,6 @@ T norm(const matrix<T>& A) {
     return std::sqrt(result);
 }
 
-
-} // namespace tws
+}  // namespace tws
 
 #endif

--- a/include/vector.hpp
+++ b/include/vector.hpp
@@ -12,7 +12,7 @@
 namespace tws {
 
 // This defines a vector as an abstract concept.
-// You can safely ignore this untill you have learned about concepts.
+// You can safely ignore this until you have learned about concepts.
 template <typename T>
 concept Scalar = std::is_arithmetic<T>::value;
 
@@ -100,7 +100,7 @@ class vector {
      * @brief Construct a new vector as a copy of another vector
      *        This does a deep copy.
      *
-     * This is a templated version, you can safely ignore this untill you
+     * This is a templated version, you can safely ignore this until you
      * have learned about expression templates and more advanced C++ features.
      *
      * @param v vector

--- a/include/vector.hpp
+++ b/include/vector.hpp
@@ -293,7 +293,7 @@ class vectorview {
     // Destructor
     ~vectorview()
     {
-        // Nothing to do here, the shared pointer will take care of the memory
+        // Nothing to do here, the view does not own the data
     }
 
     /**

--- a/include/vector.hpp
+++ b/include/vector.hpp
@@ -440,8 +440,8 @@ class vectorview {
 };
 
 // Initialize a vector with random values
-template <Scalar T>
-void randomize(vector<T>& v)
+template <Vector V>
+void randomize(V& v)
 {
     #ifdef NDEBUG
     std::random_device rd;
@@ -450,16 +450,25 @@ void randomize(vector<T>& v)
     // Note, when debugging, we want to have the same random numbers every time
     std::mt19937 gen(1302);
     #endif
-    std::normal_distribution<T> d(0, 1);
 
-    for (int i = 0; i < v.size(); ++i) {
-        v[i] = d(gen);
+    typedef typename V::val_t T;
+
+    if constexpr(std::is_integral<T>::value) {
+        std::uniform_int_distribution<T> d(0, 100);
+        for (int i = 0; i < v.size(); ++i) {
+            v[i] = d(gen);
+        }
+    } else {
+        std::normal_distribution<T> d(0, 1);
+        for (int i = 0; i < v.size(); ++i) {
+            v[i] = d(gen);
+        }
     }
 }
 
 // Code for printing
-template <Scalar T>
-void print_vector(const vector<T>& v)
+template <Vector V>
+void print_vector(const V& v)
 {
     std::cout << "(" << v.size() << ")[" << std::endl;
     for (int i = 0; i < v.size(); ++i) {

--- a/include/vector.hpp
+++ b/include/vector.hpp
@@ -13,7 +13,8 @@ namespace tws {
 
 // This defines a vector as an abstract concept.
 // You can safely ignore this untill you have learned about concepts.
-#if (__cplusplus >= 202002L)
+template<typename T>
+concept Scalar = std::is_arithmetic<T>::value;
 
 template <typename V>
 concept Vector = requires(V v)
@@ -23,14 +24,8 @@ concept Vector = requires(V v)
     {v[0]};
 };
 
-#else
-
-    #define Vector typename
-
-#endif
-
 // Forward declaration of the vectorview class
-template <typename T = double>
+template <Scalar T = double>
 class vectorview;
 
 /**
@@ -41,7 +36,7 @@ class vectorview;
  * @tparam T this is a template parameter that specifies the type of the
  *           elements of the vector.
  */
-template <typename T = double>
+template <Scalar T = double>
 class vector {
 
    public:
@@ -284,7 +279,7 @@ class vector {
  * @tparam T this is a template parameter that specifies the type of the
  *           elements of the vector.
  */
-template <typename T>
+template <Scalar T>
 class vectorview {
 
    public:
@@ -445,7 +440,7 @@ class vectorview {
 };
 
 // Initialize a vector with random values
-template <typename T>
+template <Scalar T>
 void randomize(vector<T>& v)
 {
     #ifdef NDEBUG
@@ -463,7 +458,7 @@ void randomize(vector<T>& v)
 }
 
 // Code for printing
-template <typename T>
+template <Scalar T>
 void print_vector(const vector<T>& v)
 {
     std::cout << "(" << v.size() << ")[" << std::endl;

--- a/include/vector_operations.hpp
+++ b/include/vector_operations.hpp
@@ -74,7 +74,7 @@ void sub(const V1& v1, const V2& v2, V3& result)
 }
 
 // Multiply a vector by a scalar and store the result in a new vector
-template <Vector V1, typename T>
+template <Vector V1, Scalar T>
 vector<T> operator*(const V1& v, T scalar)
 {
     vector<T> result(v.size());
@@ -85,7 +85,7 @@ vector<T> operator*(const V1& v, T scalar)
 }
 
 // Multiply a vector by a scalar and store the result in a new vector
-template <Vector V1, typename T>
+template <Vector V1, Scalar T>
 vector<T> operator*(T scalar, const V1& v)
 {
     vector<T> result(v.size());
@@ -96,7 +96,7 @@ vector<T> operator*(T scalar, const V1& v)
 }
 
 // Multiply a vector by a scalar and store the result in the vector
-template <Vector V1, typename T>
+template <Vector V1, Scalar T>
 void operator*=(V1& v, T scalar)
 {
     for (int i = 0; i < v.size(); ++i) {
@@ -105,7 +105,7 @@ void operator*=(V1& v, T scalar)
 }
 
 // Multiply a vector by a scalar and store the result in a given vector
-template <Vector V1, Vector V2, typename T>
+template <Vector V1, Vector V2, Scalar T>
 void multiply(const V1& v, T scalar, V2& result)
 {
     assert(v.size() == result.size());

--- a/include/vector_operations.hpp
+++ b/include/vector_operations.hpp
@@ -8,10 +8,11 @@
 namespace tws {
 
 // Add two vectors and store the result in a new vector
-template <typename T>
-vector<T> operator+(const vector<T>& v1, const vector<T>& v2) {
+template <Vector V1, Vector V2>
+auto operator+(const V1& v1, const V2& v2)
+{
     assert(v1.size() == v2.size());
-    vector<T> result(v1.size());
+    vector<std::remove_const_t<typename V1::val_t>> result(v1.size());
     for (int i = 0; i < v1.size(); ++i) {
         result[i] = v1[i] + v2[i];
     }
@@ -19,8 +20,9 @@ vector<T> operator+(const vector<T>& v1, const vector<T>& v2) {
 }
 
 // Add two vectors and store the result in the first vector
-template <typename T>
-void operator+=(vector<T>& v1, const vector<T>& v2) {
+template <Vector V1, Vector V2>
+void operator+=(V1& v1, const V2& v2)
+{
     assert(v1.size() == v2.size());
     for (int i = 0; i < v1.size(); ++i) {
         v1[i] += v2[i];
@@ -28,8 +30,9 @@ void operator+=(vector<T>& v1, const vector<T>& v2) {
 }
 
 // Add two vectors and store the result in a third vector
-template <typename T>
-void add(const vector<T>& v1, const vector<T>& v2, vector<T>& result) {
+template <Vector V1, Vector V2, Vector V3>
+void add(const V1& v1, const V2& v2, V3& result)
+{
     assert(v1.size() == v2.size());
     assert(v1.size() == result.size());
     for (int i = 0; i < v1.size(); ++i) {
@@ -38,10 +41,11 @@ void add(const vector<T>& v1, const vector<T>& v2, vector<T>& result) {
 }
 
 // Subtract two vectors and store the result in a new vector
-template <typename T>
-vector<T> operator-(const vector<T>& v1, const vector<T>& v2) {
+template <Vector V1, Vector V2>
+auto operator-(const V1& v1, const V2& v2)
+{
     assert(v1.size() == v2.size());
-    vector<T> result(v1.size());
+    vector<std::remove_const_t<typename V1::val_t>> result(v1.size());
     for (int i = 0; i < v1.size(); ++i) {
         result[i] = v1[i] - v2[i];
     }
@@ -49,8 +53,9 @@ vector<T> operator-(const vector<T>& v1, const vector<T>& v2) {
 }
 
 // Subtract two vectors and store the result in the first vector
-template <typename T>
-void operator-=(vector<T>& v1, const vector<T>& v2) {
+template <Vector V1, Vector V2>
+void operator-=(V1& v1, const V2& v2)
+{
     assert(v1.size() == v2.size());
     for (int i = 0; i < v1.size(); ++i) {
         v1[i] -= v2[i];
@@ -58,8 +63,9 @@ void operator-=(vector<T>& v1, const vector<T>& v2) {
 }
 
 // Subtract two vectors and store the result in a third vector
-template <typename T>
-void sub(const vector<T>& v1, const vector<T>& v2, vector<T>& result) {
+template <Vector V1, Vector V2, Vector V3>
+void sub(const V1& v1, const V2& v2, V3& result)
+{
     assert(v1.size() == v2.size());
     assert(v1.size() == result.size());
     for (int i = 0; i < v1.size(); ++i) {
@@ -68,8 +74,9 @@ void sub(const vector<T>& v1, const vector<T>& v2, vector<T>& result) {
 }
 
 // Multiply a vector by a scalar and store the result in a new vector
-template <typename T>
-vector<T> operator*(const vector<T>& v, T scalar) {
+template <Vector V1, typename T>
+vector<T> operator*(const V1& v, T scalar)
+{
     vector<T> result(v.size());
     for (int i = 0; i < v.size(); ++i) {
         result[i] = v[i] * scalar;
@@ -78,8 +85,9 @@ vector<T> operator*(const vector<T>& v, T scalar) {
 }
 
 // Multiply a vector by a scalar and store the result in a new vector
-template <typename T>
-vector<T> operator*(T scalar, const vector<T>& v) {
+template <Vector V1, typename T>
+vector<T> operator*(T scalar, const V1& v)
+{
     vector<T> result(v.size());
     for (int i = 0; i < v.size(); ++i) {
         result[i] = v[i] * scalar;
@@ -88,16 +96,18 @@ vector<T> operator*(T scalar, const vector<T>& v) {
 }
 
 // Multiply a vector by a scalar and store the result in the vector
-template <typename T>
-void operator*=(vector<T>& v, T scalar) {
+template <Vector V1, typename T>
+void operator*=(V1& v, T scalar)
+{
     for (int i = 0; i < v.size(); ++i) {
         v[i] *= scalar;
     }
 }
 
 // Multiply a vector by a scalar and store the result in a given vector
-template <typename T>
-void multiply(const vector<T>& v, T scalar, vector<T>& result) {
+template <Vector V1, Vector V2, typename T>
+void multiply(const V1& v, T scalar, V2& result)
+{
     assert(v.size() == result.size());
     for (int i = 0; i < v.size(); ++i) {
         result[i] = v[i] * scalar;
@@ -105,10 +115,11 @@ void multiply(const vector<T>& v, T scalar, vector<T>& result) {
 }
 
 // Dot product of two vectors
-template <typename T>
-T dot(const vector<T>& v1, const vector<T>& v2) {
+template <Vector V1, Vector V2>
+auto dot(const V1& v1, const V2& v2)
+{
     assert(v1.size() == v2.size());
-    T result = 0;
+    std::remove_const_t<typename V1::val_t> result = 0;
     for (int i = 0; i < v1.size(); ++i) {
         result += v1[i] * v2[i];
     }
@@ -116,11 +127,12 @@ T dot(const vector<T>& v1, const vector<T>& v2) {
 }
 
 // 2-Norm of a vector
-template <typename T>
-T norm(const vector<T>& v) {
+template <Vector V1>
+auto norm(const V1& v)
+{
     return std::sqrt(dot(v, v));
 }
 
-} // namespace tws
+}  // namespace tws
 
 #endif

--- a/test/test_matrix.cpp
+++ b/test/test_matrix.cpp
@@ -188,16 +188,14 @@ TEMPLATE_TEST_CASE("Matrixview class works", "[matrix]", double, float, int)
     int m = GENERATE(1, 2, 4, 10);
     int n = GENERATE(1, 2, 4, 10);
     int ldim = m + GENERATE(0, 1);
-    int offset = GENERATE(0, 3);
 
-    std::shared_ptr<T[]> data(new T[offset + ldim * n]);
+    std::unique_ptr<T[]> data(new T[ldim * n]);
 
-    matrixview<T> A(m, n, data, ldim, offset);
+    matrixview<T> A(m, n, data.get(), ldim);
 
     REQUIRE(A.num_rows() == m);
     REQUIRE(A.num_columns() == n);
     REQUIRE(A.ldim() == ldim);
-    REQUIRE(A.offset() == offset);
 
     for (int j = 0; j < A.num_columns(); ++j) {
         for (int i = 0; i < A.num_rows(); ++i) {
@@ -238,7 +236,8 @@ TEMPLATE_TEST_CASE("Matrixview class works", "[matrix]", double, float, int)
 
     SECTION("Test copy assignment")
     {
-        matrixview<T> B(m, n, data, ldim, offset);
+        std::unique_ptr<T[]> data2(new T[ldim * n]);
+        matrixview<T> B(m, n, data2.get(), ldim);
         B = A;
         for (int j = 0; j < B.num_columns(); ++j) {
             for (int i = 0; i < B.num_rows(); ++i) {
@@ -251,7 +250,8 @@ TEMPLATE_TEST_CASE("Matrixview class works", "[matrix]", double, float, int)
 
     SECTION("Test move assignment")
     {
-        matrixview<T> B(m, n, data, ldim, offset);
+        std::unique_ptr<T[]> data2(new T[ldim * n]);
+        matrixview<T> B(m, n, data2.get(), ldim);
         B = std::move(A);
         for (int j = 0; j < B.num_columns(); ++j) {
             for (int i = 0; i < B.num_rows(); ++i) {
@@ -357,8 +357,8 @@ TEMPLATE_TEST_CASE(
         }
     }
 
-    std::shared_ptr<T[]> data(new T[offset + ldim * n]);
-    matrixview<T> B(m, n, data, ldim, offset);
+    std::unique_ptr<T[]> data(new T[offset + ldim * n]);
+    matrixview<T> B(m, n, data.get(), ldim);
 
     for (int j = 0; j < B.num_columns(); ++j) {
         for (int i = 0; i < B.num_rows(); ++i) {
@@ -393,8 +393,8 @@ TEMPLATE_TEST_CASE("Matrix utils work", "[matrix]", double, float, int)
     randomize(A);
     print_matrix(A);
 
-    std::shared_ptr<T[]> data(new T[m * n]);
-    matrixview<T> B(m, n, data, m, 0);
+    std::unique_ptr<T[]> data(new T[m * n]);
+    matrixview<T> B(m, n, data.get(), m);
 
     randomize(B);
     print_matrix(B);

--- a/test/test_matrix.cpp
+++ b/test/test_matrix.cpp
@@ -2,7 +2,7 @@
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/generators/catch_generators.hpp>
 
-#include "matrix.hpp"
+#include "twsmatrix.hpp"
 
 using namespace tws;
 

--- a/test/test_matrix.cpp
+++ b/test/test_matrix.cpp
@@ -382,3 +382,22 @@ TEMPLATE_TEST_CASE(
         }
     }
 }
+
+
+
+TEMPLATE_TEST_CASE("Matrix utils work", "[matrix]", double, float, int)
+{
+    typedef TestType T;
+    int m = 4;
+    int n = 3;
+
+    matrix<T> A(m, n);
+    randomize(A);
+    print_matrix(A);
+
+    std::shared_ptr<T[]> data(new T[m * n]);
+    matrixview<T> B(m, n, data, m, 0);
+
+    randomize(B);
+    print_matrix(B);
+}

--- a/test/test_matrix_operations.cpp
+++ b/test/test_matrix_operations.cpp
@@ -2,9 +2,7 @@
 #include <catch2/catch_template_test_macros.hpp>
 #include <catch2/generators/catch_generators.hpp>
 
-#include "matrix.hpp"
-#include "vector.hpp"
-#include "matrix_operations.hpp"
+#include "twsmatrix.hpp"
 
 using namespace tws;
 

--- a/test/test_vector.cpp
+++ b/test/test_vector.cpp
@@ -126,9 +126,9 @@ TEMPLATE_TEST_CASE("Vectorview class works", "[vector]", double, float, int)
     int n = 5;
     int stride = GENERATE(1, 2);
 
-    std::shared_ptr<T[]> data(new T[n * stride]);
+    std::unique_ptr<T[]> data(new T[n * stride]);
 
-    vectorview<T> v(n, data, stride);
+    vectorview<T> v(n, data.get(), stride);
 
     REQUIRE(v.size() == n);
 
@@ -166,30 +166,28 @@ TEMPLATE_TEST_CASE("Vectorview class works", "[vector]", double, float, int)
 
     SECTION("Test copy assignment")
     {
-        std::shared_ptr<T[]> data_new(new T[n * stride]);
-        vectorview<T> v2(n, data_new, stride);
+        std::unique_ptr<T[]> data_new(new T[n * stride]);
+        vectorview<T> v2(n, data_new.get(), stride);
         T* data1 = v.data();
         v2 = v;
         for (int i = 0; i < v2.size(); ++i) {
             REQUIRE(v2[i] == i);
         }
         // Make sure the pointers has been copied
-        REQUIRE(data_new.use_count() == 1);
         REQUIRE(v2.data() == data1);
         REQUIRE(v.data() == data1);
     }
 
     SECTION("Test move assignment")
     {
-        std::shared_ptr<T[]> data_new(new T[n * stride]);
-        vectorview<T> v2(n, data_new, stride);
+        std::unique_ptr<T[]> data_new(new T[n * stride]);
+        vectorview<T> v2(n, data_new.get(), stride);
         T* data = v.data();
         v2 = std::move(v);
         for (int i = 0; i < v2.size(); ++i) {
             REQUIRE(v2[i] == i);
         }
         // Make sure the pointer has been moved
-        REQUIRE(data_new.use_count() == 1);
         REQUIRE(v2.data() == data);
     }
 
@@ -235,8 +233,8 @@ TEMPLATE_TEST_CASE(
     int stride = GENERATE(1, 2);
 
     vector<T> v(n);
-    std::shared_ptr<T[]> data(new T[n * stride]);
-    vectorview<T> vv(n, data, stride);
+    std::unique_ptr<T[]> data(new T[n * stride]);
+    vectorview<T> vv(n, data.get(), stride);
 
     for (int i = 0; i < v.size(); ++i) {
         v[i] = i;
@@ -266,8 +264,8 @@ TEMPLATE_TEST_CASE("Vector utils work", "[vector]", double, float, int)
     int n = 3;
 
     vector<T> v(n);
-    std::shared_ptr<T[]> data(new T[n]);
-    vectorview<T> vv(n, data, 1);
+    std::unique_ptr<T[]> data(new T[n]);
+    vectorview<T> vv(n, data.get(), 1);
 
     randomize(v);
     randomize(vv);

--- a/test/test_vector.cpp
+++ b/test/test_vector.cpp
@@ -90,12 +90,12 @@ TEMPLATE_TEST_CASE("Vector class works", "[vector]", double, float, int)
 
     SECTION("Test subvector")
     {
-        vectorview<T> v2 = v.subvector(1, n-1);
+        vectorview<T> v2 = v.subvector(1, n - 1);
         for (int i = 0; i < v2.size(); ++i) {
             REQUIRE(v2[i] == i + 1);
         }
         // Modify v2 and make sure v is modified as well
-        for( int i = 0; i < v2.size(); ++i){
+        for (int i = 0; i < v2.size(); ++i) {
             v2[i] += 1;
         }
         for (int i = 1; i < v.size() - 1; ++i) {
@@ -195,12 +195,12 @@ TEMPLATE_TEST_CASE("Vectorview class works", "[vector]", double, float, int)
 
     SECTION("Test subvector")
     {
-        vectorview<T> v2 = v.subvector(1, n-1);
+        vectorview<T> v2 = v.subvector(1, n - 1);
         for (int i = 0; i < v2.size(); ++i) {
             REQUIRE(v2[i] == i + 1);
         }
         // Modify v2 and make sure v is modified as well
-        for( int i = 0; i < v2.size(); ++i){
+        for (int i = 0; i < v2.size(); ++i) {
             v2[i] += 1;
         }
         for (int i = 1; i < v.size() - 1; ++i) {
@@ -227,7 +227,8 @@ TEMPLATE_TEST_CASE("Vectorview class works", "[vector]", double, float, int)
     }
 }
 
-TEMPLATE_TEST_CASE("Vectorview - vector interaction works", "[vector]", double, float, int)
+TEMPLATE_TEST_CASE(
+    "Vectorview - vector interaction works", "[vector]", double, float, int)
 {
     typedef TestType T;
     int n = 5;
@@ -256,7 +257,6 @@ TEMPLATE_TEST_CASE("Vectorview - vector interaction works", "[vector]", double, 
         for (int i = 0; i < v2.size(); ++i) {
             REQUIRE(v2[i] == 10 * i);
         }
-
     }
 }
 
@@ -274,4 +274,36 @@ TEMPLATE_TEST_CASE("Vector utils work", "[vector]", double, float, int)
 
     print_vector(v);
     print_vector(vv);
+}
+
+TEMPLATE_TEST_CASE(
+    "Test some weird behavior with r-values", "[vector]", double, float, int)
+{
+    typedef TestType T;
+    int n = 3;
+
+    vector<T> v(n);
+
+    for (int i = 0; i < v.size(); ++i) {
+        v[i] = 0;
+    }
+
+    SECTION("Check if view is modified if passed by value")
+    {
+        // This is expected behavior, we pass a view which should always be a reference
+        // even if passed by value.
+        add_one_value(v.subvector(0, n));
+        for (int i = 0; i < v.size(); ++i) {
+            REQUIRE(v[i] == 1);
+        }
+    }
+
+    SECTION("Check that vector is never modified, even for r-value views"){
+        // If we explicitly ask for a vector to be passed by value
+        // it should be copied and not modified.
+        add_one_value<vector<T>>(v.subvector(0, n));
+        for (int i = 0; i < v.size(); ++i) {
+            REQUIRE(v[i] == 0);
+        }
+    }
 }

--- a/test/test_vector.cpp
+++ b/test/test_vector.cpp
@@ -1,67 +1,261 @@
-#include <catch2/catch_test_macros.hpp>
 #include <catch2/catch_template_test_macros.hpp>
+#include <catch2/catch_test_macros.hpp>
 #include <catch2/generators/catch_generators.hpp>
 
 #include "vector.hpp"
 
 using namespace tws;
 
+template <Vector V>
+void add_one_ref(V& v)
+{
+    for (int i = 0; i < v.size(); ++i) {
+        v[i] += 1;
+    }
+}
+
+template <Vector V>
+void add_one_value(V v)
+{
+    for (int i = 0; i < v.size(); ++i) {
+        v[i] += 1;
+    }
+}
+
 TEMPLATE_TEST_CASE("Vector class works", "[vector]", double, float, int)
 {
     typedef TestType T;
     int n = 5;
-    int stride = GENERATE(1,2);
 
-    vector<T> v_large(n*stride);
-    vector<T> v = v_large.subvector(0, n*stride, stride);
-    for(int i = 0; i < v.size(); ++i) {
+    vector<T> v(n);
+    for (int i = 0; i < v.size(); ++i) {
         v[i] = i;
     }
 
     REQUIRE(v.size() == n);
 
-    SECTION("Test standard assignment"){
-        for(int i = 0; i < v.size(); ++i) {
+    SECTION("Test standard assignment")
+    {
+        for (int i = 0; i < v.size(); ++i) {
             REQUIRE(v[i] == i);
         }
     }
 
-    SECTION("Test copy constructor"){
+    SECTION("Test copy constructor")
+    {
         vector<T> v2(v);
-        for(int i = 0; i < v.size(); ++i) {
+        for (int i = 0; i < v.size(); ++i) {
             REQUIRE(v2[i] == i);
         }
+        // Make sure the data is not shared
+        REQUIRE(v2.data() != v.data());
     }
 
-    SECTION("Test move constructor"){
+    SECTION("Test move constructor")
+    {
+        T* data = v.data();
         vector<T> v2(std::move(v));
-        for(int i = 0; i < v2.size(); ++i) {
+        for (int i = 0; i < v2.size(); ++i) {
             REQUIRE(v2[i] == i);
         }
+        // Make sure the data is shared
+        REQUIRE(v2.data() == data);
     }
 
-    SECTION("Test copy assignment"){
+    SECTION("Test copy assignment")
+    {
         vector<T> v2(n);
+        T* data1 = v.data();
+        T* data2 = v2.data();
         v2 = v;
-        for(int i = 0; i < v2.size(); ++i) {
+        for (int i = 0; i < v2.size(); ++i) {
             REQUIRE(v2[i] == i);
         }
+        // Make sure the pointers themselves are not modified
+        REQUIRE(v2.data() == data2);
+        REQUIRE(v.data() == data1);
     }
 
-    SECTION("Test move assignment"){
+    SECTION("Test move assignment")
+    {
         vector<T> v2(n);
+        T* data = v.data();
         v2 = std::move(v);
-        for(int i = 0; i < v2.size(); ++i) {
+        for (int i = 0; i < v2.size(); ++i) {
             REQUIRE(v2[i] == i);
         }
+        // Make sure the pointer has been moved
+        REQUIRE(v2.data() == data);
     }
 
-    SECTION("Test subvector"){
-        vector<T> v2 = v.subvector(1, n-1);
-        REQUIRE(v2.size() == n-2);
-        for(int i = 0; i < v2.size(); ++i) {
-            REQUIRE(v2[i] == i+1);
+    SECTION("Test subvector")
+    {
+        vectorview<T> v2 = v.subvector(1, n-1);
+        for (int i = 0; i < v2.size(); ++i) {
+            REQUIRE(v2[i] == i + 1);
+        }
+        // Modify v2 and make sure v is modified as well
+        for( int i = 0; i < v2.size(); ++i){
+            v2[i] += 1;
+        }
+        for (int i = 1; i < v.size() - 1; ++i) {
+            REQUIRE(v[i] == i + 1);
         }
     }
 
+    SECTION("Test add_one_ref")
+    {
+        add_one_ref(v);
+        for (int i = 0; i < v.size(); ++i) {
+            REQUIRE(v[i] == i + 1);
+        }
+    }
+
+    SECTION("Test add_one_value")
+    {
+        add_one_value(v);
+        for (int i = 0; i < v.size(); ++i) {
+            REQUIRE(v[i] == i);
+        }
+    }
+}
+
+TEMPLATE_TEST_CASE("Vectorview class works", "[vector]", double, float, int)
+{
+    typedef TestType T;
+    int n = 5;
+    int stride = GENERATE(1, 2);
+
+    std::shared_ptr<T[]> data(new T[n * stride]);
+
+    vectorview<T> v(n, data, stride);
+
+    REQUIRE(v.size() == n);
+
+    for (int i = 0; i < v.size(); ++i) {
+        v[i] = i;
+    }
+
+    SECTION("Test standard assignment")
+    {
+        for (int i = 0; i < v.size(); ++i) {
+            REQUIRE(v[i] == i);
+        }
+    }
+
+    SECTION("Test copy constructor")
+    {
+        vectorview<T> v2(v);
+        for (int i = 0; i < v.size(); ++i) {
+            REQUIRE(v2[i] == i);
+        }
+        // Make sure the data is shared
+        REQUIRE(v2.data() == v.data());
+    }
+
+    SECTION("Test move constructor")
+    {
+        T* data = v.data();
+        vectorview<T> v2(std::move(v));
+        for (int i = 0; i < v2.size(); ++i) {
+            REQUIRE(v2[i] == i);
+        }
+        // Make sure the data is shared
+        REQUIRE(v2.data() == data);
+    }
+
+    SECTION("Test copy assignment")
+    {
+        std::shared_ptr<T[]> data_new(new T[n * stride]);
+        vectorview<T> v2(n, data_new, stride);
+        T* data1 = v.data();
+        v2 = v;
+        for (int i = 0; i < v2.size(); ++i) {
+            REQUIRE(v2[i] == i);
+        }
+        // Make sure the pointers has been copied
+        REQUIRE(data_new.use_count() == 1);
+        REQUIRE(v2.data() == data1);
+        REQUIRE(v.data() == data1);
+    }
+
+    SECTION("Test move assignment")
+    {
+        std::shared_ptr<T[]> data_new(new T[n * stride]);
+        vectorview<T> v2(n, data_new, stride);
+        T* data = v.data();
+        v2 = std::move(v);
+        for (int i = 0; i < v2.size(); ++i) {
+            REQUIRE(v2[i] == i);
+        }
+        // Make sure the pointer has been moved
+        REQUIRE(data_new.use_count() == 1);
+        REQUIRE(v2.data() == data);
+    }
+
+    SECTION("Test subvector")
+    {
+        vectorview<T> v2 = v.subvector(1, n-1);
+        for (int i = 0; i < v2.size(); ++i) {
+            REQUIRE(v2[i] == i + 1);
+        }
+        // Modify v2 and make sure v is modified as well
+        for( int i = 0; i < v2.size(); ++i){
+            v2[i] += 1;
+        }
+        for (int i = 1; i < v.size() - 1; ++i) {
+            REQUIRE(v[i] == i + 1);
+        }
+    }
+
+    SECTION("Test add_one_ref")
+    {
+        add_one_ref(v);
+        for (int i = 0; i < v.size(); ++i) {
+            REQUIRE(v[i] == i + 1);
+        }
+    }
+
+    SECTION("Test add_one_value")
+    {
+        add_one_value(v);
+        for (int i = 0; i < v.size(); ++i) {
+            // This may seem counterintuitive, but if the vectorview is passed
+            // by value, we expect the original data to be modified.
+            REQUIRE(v[i] == i + 1);
+        }
+    }
+}
+
+TEMPLATE_TEST_CASE("Vectorview - vector interaction works", "[vector]", double, float, int)
+{
+    typedef TestType T;
+    int n = 5;
+    int stride = GENERATE(1, 2);
+
+    vector<T> v(n);
+    std::shared_ptr<T[]> data(new T[n * stride]);
+    vectorview<T> vv(n, data, stride);
+
+    for (int i = 0; i < v.size(); ++i) {
+        v[i] = i;
+    }
+
+    for (int i = 0; i < vv.size(); ++i) {
+        vv[i] = 10 * i;
+    }
+
+    SECTION("Test vectorview -> vector")
+    {
+        v = vv;
+        for (int i = 0; i < v.size(); ++i) {
+            REQUIRE(v[i] == 10 * i);
+        }
+        vector<T> v2(vv);
+        REQUIRE(v2.size() == vv.size());
+        for (int i = 0; i < v2.size(); ++i) {
+            REQUIRE(v2[i] == 10 * i);
+        }
+
+    }
 }

--- a/test/test_vector.cpp
+++ b/test/test_vector.cpp
@@ -2,7 +2,7 @@
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/generators/catch_generators.hpp>
 
-#include "vector.hpp"
+#include "twsmatrix.hpp"
 
 using namespace tws;
 

--- a/test/test_vector.cpp
+++ b/test/test_vector.cpp
@@ -306,4 +306,11 @@ TEMPLATE_TEST_CASE(
             REQUIRE(v[i] == 0);
         }
     }
+
+    SECTION("Check that vector can be passed to view"){
+        add_one_value<vectorview<T>>(v);
+        for (int i = 0; i < v.size(); ++i) {
+            REQUIRE(v[i] == 1);
+        }
+    }
 }

--- a/test/test_vector.cpp
+++ b/test/test_vector.cpp
@@ -259,3 +259,19 @@ TEMPLATE_TEST_CASE("Vectorview - vector interaction works", "[vector]", double, 
 
     }
 }
+
+TEMPLATE_TEST_CASE("Vector utils work", "[vector]", double, float, int)
+{
+    typedef TestType T;
+    int n = 3;
+
+    vector<T> v(n);
+    std::shared_ptr<T[]> data(new T[n]);
+    vectorview<T> vv(n, data, 1);
+
+    randomize(v);
+    randomize(vv);
+
+    print_vector(v);
+    print_vector(vv);
+}

--- a/test/test_vector_operations.cpp
+++ b/test/test_vector_operations.cpp
@@ -2,8 +2,7 @@
 #include <catch2/catch_template_test_macros.hpp>
 #include <catch2/generators/catch_generators.hpp>
 
-#include "vector.hpp"
-#include "vector_operations.hpp"
+#include "twsmatrix.hpp"
 
 using namespace tws;
 


### PR DESCRIPTION
The original design was (severely) flawed.

Having a class be a mix of owning and non-owning just led to so many issues that I decided to split it up anyway.
There is now `vector` and `vectorview`, the first of which is always owning and always contiguous, the second is non-owning and can handle strided data.

I also expanded the test set to make everything works this time.